### PR TITLE
Fixed typo 'tpc' -> 'tcp'

### DIFF
--- a/source/dav/caldav-carddav-integration-guide.md
+++ b/source/dav/caldav-carddav-integration-guide.md
@@ -41,7 +41,7 @@ also how you'd want to build up your own server.
     // Directory tree
     $tree = array(
         new DAVACL\PrincipalCollection($principalBackend),
-        new CalDAV\CalendarRootNode($principalBackend, $calendarBackend)
+        new CalDAV\CalendarRoot($principalBackend, $calendarBackend)
     );	
 
 

--- a/source/dav/service-discovery.md
+++ b/source/dav/service-discovery.md
@@ -79,7 +79,7 @@ Index:
 | key               | explanation |
 | ----------------- | ----------- |
 | `_carddavs`       | type of service |
-| `_tcp`            | protocol type, always tpc |
+| `_tcp`            | protocol type, always tcp |
 | `86400`           | record timeout |
 | `IN`              | always has to be IN |
 | `SRV`             | always has to be SRV |


### PR DESCRIPTION
I'm working through the documentation, implementing the `sabre/dav` package into my project. Found a few typo's or regressions in the documentation... Might as well make a pull request out of it :)