### PR TITLE
remove php ending tags

### DIFF
--- a/source/dav/gettingstarted.md
+++ b/source/dav/gettingstarted.md
@@ -68,8 +68,6 @@ Next, create a file called `server.php`, and enter the following:
     // All we need to do now, is to fire up the server
     $server->exec();
 
-    ?>
-
 The base url
 ------------
 


### PR DESCRIPTION
those might introduce trailing whitespace after `?>` which can hurt binary streams (like pdf downloads etc)